### PR TITLE
スクロールバーの初期位置を下にする

### DIFF
--- a/OOTD/ObservableObjects/ItemStore.swift
+++ b/OOTD/ObservableObjects/ItemStore.swift
@@ -53,7 +53,7 @@ class ItemStore: ObservableObject {
         queries = [defaultQuery] + Category.allCases.map { category in
             ItemQuery(
                 name: category.rawValue,
-                sort: .createdAtDescendant,
+                sort: .createdAtAscendant,
                 filter: .init(
                     category: category
                 )

--- a/OOTD/Views/Item/ItemGrid.swift
+++ b/OOTD/Views/Item/ItemGrid.swift
@@ -292,6 +292,7 @@ struct ItemGrid: HashableView {
                         .padding(spacing)
                         .padding(.bottom, 70)
                     }
+                    .defaultScrollAnchor(.bottom)
                     .background(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))
                 }
             } footer: {

--- a/OOTD/Views/Item/ItemGrid.swift
+++ b/OOTD/Views/Item/ItemGrid.swift
@@ -49,20 +49,20 @@ struct ItemGrid: HashableView {
     @State private var activeSheet: ActiveSheet?
     @State private var activeTabIndex: Int = 0
 
+    var activeTab: ItemStore.Tab? {
+        guard itemStore.tabs.indices.contains(activeTabIndex) else {
+            return nil
+        }
+        return itemStore.tabs[activeTabIndex]
+    }
+
     var relatedOutfits: [Outfit] {
         outfitStore.getOutfits(using: selected)
     }
 
     var sortButton: some View {
-        let text: String
-        if itemStore.tabs.indices.contains(activeTabIndex) {
-            text = itemStore.tabs[activeTabIndex].query.sort.rawValue
-        } else {
-            text = "並べ替え"
-        }
-
         return footerButton(
-            text: text,
+            text: activeTab?.query.sort.rawValue ?? "並べ替え",
             systemName: "arrow.up.arrow.down"
         ) {
             activeSheet = .selectSort
@@ -263,7 +263,8 @@ struct ItemGrid: HashableView {
 
     var selectSortSheet: some View {
         SelectSheet(
-            options: ItemQuery.Sort.allCases.map(\.rawValue)
+            options: ItemQuery.Sort.allCases.map(\.rawValue),
+            currentValue: activeTab?.query.sort.rawValue
         ) { sort in
             if itemStore.tabs.indices.contains(activeTabIndex) {
                 itemStore.queries[activeTabIndex].sort = ItemQuery.Sort(rawValue: sort)!

--- a/OOTD/Views/Outfit/OutfitGrid.swift
+++ b/OOTD/Views/Outfit/OutfitGrid.swift
@@ -111,7 +111,7 @@ struct OutfitGrid: View {
 
     var sortButton: some View {
         footerButton(
-            text: "並べ替え",
+            text: tab.sort.rawValue,
             systemName: "arrow.up.arrow.down"
         ) {
             activeSheet = .selectSort
@@ -184,7 +184,8 @@ struct OutfitGrid: View {
 
     var selectSortSheet: some View {
         SelectSheet(
-            options: OutfitGridTab.Sort.allCases.map(\.rawValue)
+            options: OutfitGridTab.Sort.allCases.map(\.rawValue),
+            currentValue: tab.sort.rawValue
         ) { sort in
             tab.sort = OutfitGridTab.Sort(rawValue: sort)!
             activeSheet = nil

--- a/OOTD/Views/Outfit/OutfitGrid.swift
+++ b/OOTD/Views/Outfit/OutfitGrid.swift
@@ -19,7 +19,7 @@ struct OutfitGrid: View {
     @State private var isAlertPresented = false
     @State private var tab = OutfitGridTab(
         name: "すべて",
-        sort: .createdAtDescendant
+        sort: .createdAtAscendant
     )
     @State private var activeSheet: Sheet?
     enum Sheet: Int, Identifiable {
@@ -220,6 +220,7 @@ struct OutfitGrid: View {
                         .padding(.bottom, 70)
                         .padding(spacing)
                     }
+                    .defaultScrollAnchor(.bottom)
                     .background(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))
 
                     bottomBar

--- a/OOTD/Views/Sheets/SelectSheet.swift
+++ b/OOTD/Views/Sheets/SelectSheet.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SelectSheet: HashableView {
     let options: [String]
+    var currentValue: String?
     var onSelect: (String) -> Void = { _ in }
 
     var height: CGFloat {
@@ -21,6 +22,9 @@ struct SelectSheet: HashableView {
                 onSelect(option)
             } label: {
                 Text(option)
+                    .if(currentValue == option) {
+                        $0.bold()
+                    }
             }
             Spacer()
         }
@@ -52,7 +56,8 @@ struct SelectSheet: HashableView {
                 SelectSheet(
                     options: Array(0 ..< numOptions).map {
                         "選択肢\($0)"
-                    }
+                    },
+                    currentValue: "選択肢1"
                 )
             }
         }


### PR DESCRIPTION
# 概要

スクロールバーの初期位置を下にした。

ついでに SelectSheet で現在利用中の選択肢を太字にした。


# 目的

OOTD では [親指中心UI](https://www.scotthurff.com/posts/how-to-design-for-thumbs-in-the-era-of-huge-screens/) を目指していて、ユーザーが使い慣れた iPhone のカメラロールのように、新しいアイテム・コーデが親指の近くに来るようにしたいから。デフォルトの順番も古い順にした。