### PR TITLE
ScrollView の表示内容が少ないとき下詰め配置になるバグの修正

### DIFF
--- a/OOTD/Views/Components/ScrollableTabView.swift
+++ b/OOTD/Views/Components/ScrollableTabView.swift
@@ -104,7 +104,7 @@ struct ScrollableTabView<Data: RandomAccessCollection, Content: View, ID: Hashab
                     }
 
                     ScrollView(.horizontal, showsIndicators: false) {
-                        LazyHStack(spacing: 0) {
+                        HStack(spacing: 0) {
                             ForEach(data, id: id) {
                                 content($0)
                                     .frame(width: geometry.size.width)


### PR DESCRIPTION
# どういうバグか

アイテム一覧画面の各タブごとの縦の ScrollView の配置が下詰めになってしまう。
ただし、画面を軽く上にスクロール（下にスワイプ）すると、配置が上詰めに戻る。


# 発生条件

- 偶発的に発生（原因不明のため、そう見えてるだけかも）
- 表示内容が表示範囲よりも小さい（アイテム数が4個くらい）とき

# 再現手順

アイテム一覧画面を開き、カテゴリーごとの下タブを移動すると、たまに ScrollView の配置が下詰めになる。

# 原因

詳細は不明だが、 https://github.com/hrsma2i/ootd-ios/pull/4 以来、発生するようになった。
`.defaultScrollAnchor(.bottom)` を ScrollableTabView 内で使うことが悪さをしてるようだった。
ItemStore.tabs の更新方法を変えたのが原因ではなさそう。理由は、ScrollabelView の #Preview に記載したサンプルでも同様の問題が確認できたから。

# なぜ HStack に変えたか

理由はわからないが、謎の勘が働き、 ScrollableTabView の LazyHStack を HStack にしたら解消したようだ（偶発的なバグなので、真に解消したかは不明）。

# 副次的な効果

下タブ切り替え時に描画が速くなった気がする。Lazy*　系はフレームアウトすると View が破棄されていたので。