### PR TITLE
DB更新後に状態の更新をする

### DIFF
--- a/OOTD.xcodeproj/project.pbxproj
+++ b/OOTD.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		886232B52C7CCA7800A1802D /* UserInfoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886232B12C7CCA7800A1802D /* UserInfoScreen.swift */; };
 		886232B92C7CCB5000A1802D /* ItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886232B82C7CCB5000A1802D /* ItemCard.swift */; };
 		886232BD2C7CCC9100A1802D /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886232BC2C7CCC9100A1802D /* NavigationManager.swift */; };
+		88886D442CFC67C100570687 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88886D432CFC67C100570687 /* LoadingView.swift */; };
 		889F34FC2CBF991100C5BD65 /* ItemQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F34FB2CBF991100C5BD65 /* ItemQuery.swift */; };
 		889F34FE2CBFDAC600C5BD65 /* ScrollableTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F34FD2CBFDAC600C5BD65 /* ScrollableTabView.swift */; };
 		88A350032CA86DD300021FBF /* SelectWebItemScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A350022CA86DD300021FBF /* SelectWebItemScreen.swift */; };
@@ -279,6 +280,7 @@
 		886232B12C7CCA7800A1802D /* UserInfoScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoScreen.swift; sourceTree = "<group>"; };
 		886232B82C7CCB5000A1802D /* ItemCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCard.swift; sourceTree = "<group>"; };
 		886232BC2C7CCC9100A1802D /* NavigationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		88886D432CFC67C100570687 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		889F34FB2CBF991100C5BD65 /* ItemQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemQuery.swift; sourceTree = "<group>"; };
 		889F34FD2CBFDAC600C5BD65 /* ScrollableTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableTabView.swift; sourceTree = "<group>"; };
 		88A350022CA86DD300021FBF /* SelectWebItemScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWebItemScreen.swift; sourceTree = "<group>"; };
@@ -657,6 +659,7 @@
 				889F34FD2CBFDAC600C5BD65 /* ScrollableTabView.swift */,
 				88B012AC2CC1341E00CD9153 /* EditableTagListView.swift */,
 				88D8EF0D2CE231630070AD8D /* AdBanner.swift */,
+				88886D432CFC67C100570687 /* LoadingView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1060,6 +1063,7 @@
 				883FCB392C9674060001DAAF /* Sequence+unique.swift in Sources */,
 				88CD55A22C874E9800A9B78A /* SelectWebImageScreen.swift in Sources */,
 				886232A72C7CC7D100A1802D /* View+functionalModifier.swift in Sources */,
+				88886D442CFC67C100570687 /* LoadingView.swift in Sources */,
 				88004E2D2CB4363700A80A80 /* ZozoItemDetail.swift in Sources */,
 				88AAE5AC2CC3EF5200DAEC0F /* FlowLayout.swift in Sources */,
 				886232892C7CC71F00A1802D /* SelectedItemsGrid.swift in Sources */,

--- a/OOTD.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OOTD.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
       "state" : {
-        "revision" : "74f2ec169551c3b924947b473716142a0b983e10",
-        "version" : "2.6.0"
+        "revision" : "708a282840c2171ee63bd93b87afa49fe507d70e",
+        "version" : "2.7.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup",
       "state" : {
-        "revision" : "3c2c7e1e72b8abd96eafbae80323c5c1e5317437",
-        "version" : "2.7.5"
+        "revision" : "0837db354faf9c9deb710dc597046edaadf5360f",
+        "version" : "2.7.6"
       }
     },
     {

--- a/OOTD/Views/Components/LoadingView.swift
+++ b/OOTD/Views/Components/LoadingView.swift
@@ -1,0 +1,34 @@
+//
+//  LoadingView.swift
+//  OOTD
+//
+//  Created by Hiroshi Matsui on 2024/12/01.
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    var text: String = "保存中..."
+
+    var body: some View {
+        ZStack {
+            Color(gray: 0.7)
+                .opacity(0.7)
+
+            VStack(spacing: 15) {
+                ProgressView()
+                    .tint(.white)
+                Text(text)
+                    .foregroundColor(.init(gray: 0.9))
+                    .bold()
+            }
+            .padding(40)
+            .background(Color(gray: 0.1).opacity(0.7))
+            .cornerRadius(10)
+        }
+    }
+}
+
+#Preview {
+    LoadingView(text: "保存中...")
+}

--- a/OOTD/Views/Item/ItemDetail.swift
+++ b/OOTD/Views/Item/ItemDetail.swift
@@ -59,7 +59,11 @@ struct ItemDetail: HashableView {
             systemName: "checkmark",
             fontSize: 20
         ) {
-            Task {
+            Task { @MainActor in
+                defer {
+                    navigation.path.removeLast()
+                }
+                
                 switch mode {
                 case .create:
                     try await itemStore.create(items)
@@ -67,8 +71,6 @@ struct ItemDetail: HashableView {
                     try await itemStore.update(items, originalItems: originalItems)
                 }
             }
-                
-            navigation.path.removeLast()
         }
     }
     
@@ -388,15 +390,15 @@ struct ItemDetail: HashableView {
         AdBannerContainer {
             ScrollView {
                 imageArea
-                
+                    
                 VStack(spacing: 20) {
                     nameRow
-                    
+                        
                     tagsRow
-                    
+                        
                     section {
                         categoryRow
-                        
+                            
                         if items.count == 1, let item = items.first {
                             Divider()
                             propertyRow("作成日時", item.createdAt?.toString() ?? "----/--/-- --:--:--")
@@ -408,7 +410,7 @@ struct ItemDetail: HashableView {
                             }
                         }
                     }
-                    
+                        
                     if Config.IS_DEBUG_MODE, items.count == 1, let item = items.first {
                         section {
                             priceRow(item)

--- a/OOTD/Views/Item/ItemGrid.swift
+++ b/OOTD/Views/Item/ItemGrid.swift
@@ -315,15 +315,18 @@ struct ItemGrid: HashableView {
         .alert("本当に削除しますか？", isPresented: $isAlertPresented) {
             Button(role: .cancel) {} label: { Text("戻る") }
             Button(role: .destructive) {
-                Task {
+                Task { @MainActor in
+                    defer {
+                        selected = []
+                        isSelectable = false
+                    }
+
                     do {
                         try await itemStore.delete(selected)
-                        selected = []
                     } catch {
                         logger.error("\(error)")
                     }
                 }
-                isSelectable = false
             } label: { Text("削除する") }
         } message: {
             Text("選択中のアイテムが削除されます。")

--- a/OOTD/Views/Outfit/OutfitDetail.swift
+++ b/OOTD/Views/Outfit/OutfitDetail.swift
@@ -213,7 +213,11 @@ struct OutfitDetail: HashableView {
                         systemName: "checkmark",
                         fontSize: 20
                     ) {
-                        Task {
+                        Task { @MainActor in
+                            defer {
+                                navigation.path.removeLast()
+                            }
+
                             do {
                                 switch mode {
                                 case .create:
@@ -225,8 +229,6 @@ struct OutfitDetail: HashableView {
                                 logger.error("\(error)")
                             }
                         }
-
-                        navigation.path.removeLast()
                     }
                 }
             }

--- a/OOTD/Views/Outfit/OutfitGrid.swift
+++ b/OOTD/Views/Outfit/OutfitGrid.swift
@@ -238,9 +238,12 @@ struct OutfitGrid: View {
         .alert("本当に削除しますか？", isPresented: $isAlertPresented) {
             Button(role: .cancel) {} label: { Text("戻る") }
             Button(role: .destructive) {
-                isSelectable = false
+                Task { @MainActor in
+                    defer {
+                        isSelectable = false
+                        selected = []
+                    }
 
-                Task {
                     do {
                         try await outfitStore.delete(selected)
                     } catch {

--- a/OOTD/Views/RootView.swift
+++ b/OOTD/Views/RootView.swift
@@ -16,32 +16,38 @@ struct RootView: View {
     @StateObject private var navigation = NavigationManager()
 
     var body: some View {
-        NavigationStack(path: $navigation.path) {
-            TabView {
-                OutfitGrid()
-                    .tabItem {
-                        VStack {
-                            Text("コーデ")
-                            Image("outfit")
-                        }
-                    }
-
-                ItemGrid()
-                    .tabItem {
-                        VStack {
-                            Text("アイテム")
-                            Image("t-shirt")
-                        }
-                    }
-
-                if Config.IS_DEBUG_MODE {
-                    UserInfoScreen()
+        ZStack {
+            NavigationStack(path: $navigation.path) {
+                TabView {
+                    OutfitGrid()
                         .tabItem {
-                            Label("ユーザー", systemImage: "person.crop.circle")
+                            VStack {
+                                Text("コーデ")
+                                Image("outfit")
+                            }
                         }
+
+                    ItemGrid()
+                        .tabItem {
+                            VStack {
+                                Text("アイテム")
+                                Image("t-shirt")
+                            }
+                        }
+
+                    if Config.IS_DEBUG_MODE {
+                        UserInfoScreen()
+                            .tabItem {
+                                Label("ユーザー", systemImage: "person.crop.circle")
+                            }
+                    }
                 }
+                .navigationDestination(for: ItemDetail.self) { $0 }
             }
-            .navigationDestination(for: ItemDetail.self) { $0 }
+
+            if itemStore.isWriting {
+                LoadingView()
+            }
         }
         .environmentObject(itemStore)
         .environmentObject(outfitStore)

--- a/OOTD/Views/RootView.swift
+++ b/OOTD/Views/RootView.swift
@@ -45,7 +45,7 @@ struct RootView: View {
                 .navigationDestination(for: ItemDetail.self) { $0 }
             }
 
-            if itemStore.isWriting {
+            if itemStore.isWriting || outfitStore.isWriting {
                 LoadingView()
             }
         }

--- a/OOTD/Views/WebView/SelectWebItemScreen.swift
+++ b/OOTD/Views/WebView/SelectWebItemScreen.swift
@@ -49,7 +49,13 @@ struct SelectWebItemScreen: HashableView {
                 fontSize: 20,
                 radius: 5
             ) {
-                Task {
+                Task { @MainActor in
+                    itemStore.isWriting = true
+
+                    defer {
+                        navigation.path = NavigationPath()
+                    }
+
                     let items = await selected.asyncMap { item in
                         do {
                             return try await item.copyWithPropertiesFromSourceUrl()
@@ -61,7 +67,6 @@ struct SelectWebItemScreen: HashableView {
 
                     try await itemStore.create(items)
                 }
-                navigation.path = NavigationPath()
             }
             .padding(7)
         }

--- a/OOTD/Views/WebView/WebItemDetail.swift
+++ b/OOTD/Views/WebView/WebItemDetail.swift
@@ -158,11 +158,13 @@ struct WebItemDetail: HashableView {
                 systemName: "checkmark",
                 fontSize: 20
             ) {
-                Task {
+                Task { @MainActor in
+                    defer {
+                        navigation.path.removeLast()
+                        onCreated(item)
+                    }
                     try await itemStore.create([item])
                 }
-                navigation.path.removeLast()
-                onCreated(item)
             }
         }
     }


### PR DESCRIPTION
# 概要

もともと、ItemStore と OutfitStore でDB更新とアプリの状態の更新を並行で行っていたが、DB → 状態の順で更新することにした。

# 目的

DB と状態の乖離を防ぐため。

DDD やクリーンアーキテクチャを目指し、 *Store.update 内の共通の前処理ロジックをユースケース（EditItems, EditOutfits）側に移譲したいため。 updatedAt の更新も含め。

.createAt の生成を Item, Outfit のコンストラクタ内に移譲するため。

