### PR TITLE
*Store 書き込みの成否をスナックバーに表示する

### DIFF
--- a/OOTD.xcodeproj/project.pbxproj
+++ b/OOTD.xcodeproj/project.pbxproj
@@ -106,9 +106,13 @@
 		886232B52C7CCA7800A1802D /* UserInfoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886232B12C7CCA7800A1802D /* UserInfoScreen.swift */; };
 		886232B92C7CCB5000A1802D /* ItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886232B82C7CCB5000A1802D /* ItemCard.swift */; };
 		886232BD2C7CCC9100A1802D /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886232BC2C7CCC9100A1802D /* NavigationManager.swift */; };
+		887E631A2CFD4EE5006F52C0 /* Snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887E63192CFD4EE5006F52C0 /* Snackbar.swift */; };
+		887E631C2CFD745C006F52C0 /* View+snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887E631B2CFD745C006F52C0 /* View+snackbar.swift */; };
 		88886D442CFC67C100570687 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88886D432CFC67C100570687 /* LoadingView.swift */; };
 		889F34FC2CBF991100C5BD65 /* ItemQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F34FB2CBF991100C5BD65 /* ItemQuery.swift */; };
 		889F34FE2CBFDAC600C5BD65 /* ScrollableTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F34FD2CBFDAC600C5BD65 /* ScrollableTabView.swift */; };
+		88A036D62CFDE91D003E2E89 /* SnackbarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A036D52CFDE91D003E2E89 /* SnackbarStore.swift */; };
+		88A036D82CFDEE08003E2E89 /* Color+softRed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A036D72CFDEE08003E2E89 /* Color+softRed.swift */; };
 		88A350032CA86DD300021FBF /* SelectWebItemScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A350022CA86DD300021FBF /* SelectWebItemScreen.swift */; };
 		88AAE5AC2CC3EF5200DAEC0F /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AAE5AB2CC3EF5200DAEC0F /* FlowLayout.swift */; };
 		88AAE5AE2CC4908F00DAEC0F /* MasonryVGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AAE5AD2CC4908F00DAEC0F /* MasonryVGrid.swift */; };
@@ -280,9 +284,13 @@
 		886232B12C7CCA7800A1802D /* UserInfoScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoScreen.swift; sourceTree = "<group>"; };
 		886232B82C7CCB5000A1802D /* ItemCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCard.swift; sourceTree = "<group>"; };
 		886232BC2C7CCC9100A1802D /* NavigationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		887E63192CFD4EE5006F52C0 /* Snackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snackbar.swift; sourceTree = "<group>"; };
+		887E631B2CFD745C006F52C0 /* View+snackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+snackbar.swift"; sourceTree = "<group>"; };
 		88886D432CFC67C100570687 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		889F34FB2CBF991100C5BD65 /* ItemQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemQuery.swift; sourceTree = "<group>"; };
 		889F34FD2CBFDAC600C5BD65 /* ScrollableTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableTabView.swift; sourceTree = "<group>"; };
+		88A036D52CFDE91D003E2E89 /* SnackbarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackbarStore.swift; sourceTree = "<group>"; };
+		88A036D72CFDEE08003E2E89 /* Color+softRed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+softRed.swift"; sourceTree = "<group>"; };
 		88A350022CA86DD300021FBF /* SelectWebItemScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWebItemScreen.swift; sourceTree = "<group>"; };
 		88AAE5AB2CC3EF5200DAEC0F /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		88AAE5AD2CC4908F00DAEC0F /* MasonryVGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonryVGrid.swift; sourceTree = "<group>"; };
@@ -469,6 +477,7 @@
 			children = (
 				883FCB3E2C99BB560001DAAF /* Color+gray.swift */,
 				8862329C2C7CC7D100A1802D /* Color+textColorBasedOnBrightness.swift */,
+				88A036D72CFDEE08003E2E89 /* Color+softRed.swift */,
 			);
 			path = Color;
 			sourceTree = "<group>";
@@ -508,6 +517,7 @@
 				8862329F2C7CC7D100A1802D /* View+functionalModifier.swift */,
 				883FCB402C99C82E0001DAAF /* View+edgeSwipe.swift */,
 				886232A02C7CC7D100A1802D /* View+if.swift */,
+				887E631B2CFD745C006F52C0 /* View+snackbar.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -621,6 +631,7 @@
 				886232512C7CC2A700A1802D /* ItemStore.swift */,
 				886232552C7CC2EE00A1802D /* OutfitStore.swift */,
 				886232BC2C7CCC9100A1802D /* NavigationManager.swift */,
+				88A036D52CFDE91D003E2E89 /* SnackbarStore.swift */,
 			);
 			path = ObservableObjects;
 			sourceTree = "<group>";
@@ -660,6 +671,7 @@
 				88B012AC2CC1341E00CD9153 /* EditableTagListView.swift */,
 				88D8EF0D2CE231630070AD8D /* AdBanner.swift */,
 				88886D432CFC67C100570687 /* LoadingView.swift */,
+				887E63192CFD4EE5006F52C0 /* Snackbar.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1061,6 +1073,7 @@
 				88CD559F2C8749E800A9B78A /* CustomWebView.swift in Sources */,
 				884CF6702C8201F900250026 /* AddButton.swift in Sources */,
 				883FCB392C9674060001DAAF /* Sequence+unique.swift in Sources */,
+				887E631C2CFD745C006F52C0 /* View+snackbar.swift in Sources */,
 				88CD55A22C874E9800A9B78A /* SelectWebImageScreen.swift in Sources */,
 				886232A72C7CC7D100A1802D /* View+functionalModifier.swift in Sources */,
 				88886D442CFC67C100570687 /* LoadingView.swift in Sources */,
@@ -1068,6 +1081,7 @@
 				88AAE5AC2CC3EF5200DAEC0F /* FlowLayout.swift in Sources */,
 				886232892C7CC71F00A1802D /* SelectedItemsGrid.swift in Sources */,
 				88CD55942C8745C700A9B78A /* ItemAddSelectWebSiteScreen.swift in Sources */,
+				88A036D82CFDEE08003E2E89 /* Color+softRed.swift in Sources */,
 				88B2BCE92C7E0E89008F45B7 /* SwiftDataItemRepository.swift in Sources */,
 				886232402C7CC08600A1802D /* ItemGrid.swift in Sources */,
 				88004E242CB4302100A80A80 /* EcItemDetail.swift in Sources */,
@@ -1125,6 +1139,7 @@
 				88E3DC3E2CC7D8FF0006D201 /* ItemDTOV7.swift in Sources */,
 				883FCB372C9671870001DAAF /* String+matches.swift in Sources */,
 				88B012B12CC15F0900CD9153 /* SchemaV5.swift in Sources */,
+				88A036D62CFDE91D003E2E89 /* SnackbarStore.swift in Sources */,
 				886064132C90790D003C7001 /* Sequence+compactMapWithErrorLog.swift in Sources */,
 				886232B32C7CCA7800A1802D /* OutfitGrid.swift in Sources */,
 				884F5A752CF76033004228C6 /* DeleteItems.swift in Sources */,
@@ -1146,6 +1161,7 @@
 				883FCB452C9C5F4C0001DAAF /* DetailMode.swift in Sources */,
 				883FCB2E2C90815F0001DAAF /* SwiftDataManager.swift in Sources */,
 				8862325E2C7CC2FF00A1802D /* SampleOutfitRepository.swift in Sources */,
+				887E631A2CFD4EE5006F52C0 /* Snackbar.swift in Sources */,
 				886232A62C7CC7D100A1802D /* UIImage+resized.swift in Sources */,
 				886232B42C7CCA7800A1802D /* OutfitGridTabDetail.swift in Sources */,
 				886232912C7CC71F00A1802D /* OutfitsRow.swift in Sources */,
@@ -1266,7 +1282,7 @@
 		};
 		8862322F2C7CBDDA00A1802D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88DDFC0A2CF359180022BA8F /* qa.xcconfig */;
+			baseConfigurationReference = 884CF6532C7F599300250026 /* swiftData.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/OOTD/ObservableObjects/ItemStore.swift
+++ b/OOTD/ObservableObjects/ItemStore.swift
@@ -148,9 +148,7 @@ class ItemStore: ObservableObject {
                 return edited
             }
         } else {
-            // TODO: ちゃんと例外を投げる
-            logger.error("originalItems is empty and originalItems.count != editedItems.count")
-            return
+            throw "originalItems is empty and originalItems.count != editedItems.count"
         }
 
         let now = Date()

--- a/OOTD/ObservableObjects/OutfitStore.swift
+++ b/OOTD/ObservableObjects/OutfitStore.swift
@@ -83,9 +83,7 @@ class OutfitStore: ObservableObject {
                 return edited
             }
         } else {
-            // TODO: ちゃんと例外を投げる
-            logger.error("originalOutfits is empty and originalOutfits.count != editedOutfits.count")
-            return
+            throw "originalOutfits is empty and originalOutfits.count != editedOutfits.count"
         }
 
         let now = Date()

--- a/OOTD/ObservableObjects/SnackbarStore.swift
+++ b/OOTD/ObservableObjects/SnackbarStore.swift
@@ -1,0 +1,51 @@
+//
+//  SnackbarStore.swift
+//  OOTD
+//
+//  Created by Hiroshi Matsui on 2024/12/02.
+//
+
+import Foundation
+import os
+
+class SnackbarStore: ObservableObject {
+    @Published var active: Snackbar?
+
+    @MainActor
+    private func dismiss() {
+        active = nil
+    }
+
+    @MainActor
+    func notify(_ logger: Logger, process: @escaping () async throws -> Void) async {
+        do {
+            try await process()
+            notifySuccess()
+        } catch {
+            logger.error("\(error)")
+            notifyFailure()
+        }
+    }
+
+    @MainActor
+    private func notifySuccess() {
+        active = Snackbar(
+            message: "成功しました",
+            buttonText: "閉じる"
+        ) {
+            self.dismiss()
+        }
+    }
+
+    @MainActor
+    private func notifyFailure() {
+        active = Snackbar(
+            message: "失敗しました",
+            buttonText: "閉じる",
+            buttonTextColor: .white,
+            backgroundColor: .softRed
+        ) {
+            self.dismiss()
+        }
+    }
+}

--- a/OOTD/Shared/Extensions/Color/Color+softRed.swift
+++ b/OOTD/Shared/Extensions/Color/Color+softRed.swift
@@ -1,0 +1,13 @@
+//
+//  Color+softRed.swift
+//  OOTD
+//
+//  Created by Hiroshi Matsui on 2024/12/02.
+//
+
+import Foundation
+import SwiftUI
+
+extension Color {
+    static let softRed = Color(red: 255 / 255, green: 117 / 255, blue: 117 / 255)
+}

--- a/OOTD/Shared/Extensions/View/View+snackbar.swift
+++ b/OOTD/Shared/Extensions/View/View+snackbar.swift
@@ -1,0 +1,114 @@
+//
+//  View+snackbar.swift
+//  OOTD
+//
+//  Created by Hiroshi Matsui on 2024/12/02.
+//
+
+import SwiftUI
+
+struct SnackbarModifier<SnackbarContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let duration: TimeInterval
+    @ViewBuilder let snackbarContent: () -> SnackbarContent
+
+    func body(content: Content) -> some View {
+        content
+            .safeAreaInset(edge: .bottom) {
+                if isPresented {
+                    snackbarContent()
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 16)
+                        .transition(.move(edge: .bottom).combined(with: .opacity)) // スライドイン + フェード
+                        .task {
+                            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+                            withAnimation {
+                                isPresented = false
+                            }
+                        }
+                } else {
+                    EmptyView()
+                }
+            }
+            .animation(.easeInOut, value: isPresented)
+    }
+}
+
+struct SnackbarItemModifier<Item: Hashable, SnackbarContent: View>: ViewModifier {
+    @Binding var item: Item?
+    let duration: TimeInterval
+    @ViewBuilder let snackbarContent: (Item) -> SnackbarContent
+
+    func body(content: Content) -> some View {
+        content
+            .safeAreaInset(edge: .bottom) {
+                if let item = item {
+                    snackbarContent(item)
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 16)
+                        .transition(.move(edge: .bottom).combined(with: .opacity)) // スライドイン + フェード
+                        .task {
+                            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+                            withAnimation {
+                                self.item = nil
+                            }
+                        }
+                } else {
+                    EmptyView()
+                }
+            }
+            .animation(.easeInOut, value: item)
+    }
+}
+
+extension View {
+    func snackbar<SnackbarContent: View>(
+        isPresented: Binding<Bool>,
+        duration: TimeInterval = 3.0,
+        @ViewBuilder snackbarContent: @escaping () -> SnackbarContent
+    ) -> some View {
+        modifier(SnackbarModifier(isPresented: isPresented, duration: duration, snackbarContent: snackbarContent))
+    }
+
+    func snackbar<Item: Hashable, SnackbarContent: View>(
+        item: Binding<Item?>,
+        duration: TimeInterval = 3.0,
+        @ViewBuilder snackbarContent: @escaping (Item) -> SnackbarContent
+    ) -> some View {
+        modifier(SnackbarItemModifier(item: item, duration: duration, snackbarContent: snackbarContent))
+    }
+}
+
+#Preview {
+    struct PreviewView: View {
+        @State var activeSnackbar: Snackbar?
+
+        var body: some View {
+            VStack(spacing: 50) {
+                Button("show success snackbar") {
+                    activeSnackbar = Snackbar(
+                        message: "保存されました",
+                        buttonText: "閉じる"
+                    ) {
+                        activeSnackbar = nil
+                    }
+                }
+
+                Button("show failure snackbar") {
+                    activeSnackbar = Snackbar(
+                        message: "失敗しました",
+                        buttonText: "閉じる",
+                        buttonTextColor: .white,
+                        backgroundColor: .red
+                    ) {
+                        activeSnackbar = nil
+                    }
+                }
+                .foregroundColor(.red)
+            }
+            .snackbar(item: $activeSnackbar) { $0 }
+        }
+    }
+
+    return PreviewView()
+}

--- a/OOTD/Views/Components/Snackbar.swift
+++ b/OOTD/Views/Components/Snackbar.swift
@@ -1,0 +1,47 @@
+//
+//  Snackbar.swift
+//  OOTD
+//
+//  Created by Hiroshi Matsui on 2024/12/02.
+//
+
+import SwiftUI
+
+struct Snackbar: HashableView {
+    let message: String
+    let buttonText: String?
+    var textColor = Color.white
+    var buttonTextColor = Color(red: 163/255, green: 194/255, blue: 255/255)
+    var backgroundColor = Color(gray: 0.3)
+    var duration: TimeInterval = 5.0
+    var cornerRadius: CGFloat = 5.0
+    var action: () -> Void = {}
+
+    var body: some View {
+        HStack {
+            Text(message)
+                .foregroundColor(textColor)
+            Spacer()
+
+            if let buttonText {
+                Button(action: action) {
+                    Text(buttonText)
+                        .bold()
+                        .foregroundColor(buttonTextColor)
+                }
+            }
+        }
+        .padding()
+        .background(backgroundColor)
+        .cornerRadius(cornerRadius)
+        .shadow(radius: 5)
+    }
+}
+
+#Preview {
+    Snackbar(
+        message: "保存しました",
+        buttonText: "閉じる"
+    )
+    .padding()
+}

--- a/OOTD/Views/Item/ItemDetail.swift
+++ b/OOTD/Views/Item/ItemDetail.swift
@@ -14,6 +14,7 @@ struct ItemDetail: HashableView {
     let mode: DetailMode
     @EnvironmentObject var itemStore: ItemStore
     @EnvironmentObject var navigation: NavigationManager
+    @EnvironmentObject var snackbarStore: SnackbarStore
     
     // MARK: - private
     
@@ -64,11 +65,13 @@ struct ItemDetail: HashableView {
                     navigation.path.removeLast()
                 }
                 
-                switch mode {
-                case .create:
-                    try await itemStore.create(items)
-                case .update:
-                    try await itemStore.update(items, originalItems: originalItems)
+                await snackbarStore.notify(logger) {
+                    switch mode {
+                    case .create:
+                        try await itemStore.create(items)
+                    case .update:
+                        try await itemStore.update(items, originalItems: originalItems)
+                    }
                 }
             }
         }

--- a/OOTD/Views/Item/ItemGrid.swift
+++ b/OOTD/Views/Item/ItemGrid.swift
@@ -22,6 +22,7 @@ struct ItemGrid: HashableView {
     @EnvironmentObject var itemStore: ItemStore
     @EnvironmentObject var outfitStore: OutfitStore
     @EnvironmentObject var navigation: NavigationManager
+    @EnvironmentObject var snackbarStore: SnackbarStore
 
     // MARK: - optional
 
@@ -116,7 +117,7 @@ struct ItemGrid: HashableView {
         footerButton(
             text: "一括削除",
             systemName: "trash.fill",
-            color: Color(red: 255 / 255, green: 117 / 255, blue: 117 / 255)
+            color: .softRed
         ) {
             if relatedOutfits.isEmpty {
                 isAlertPresented = true
@@ -321,10 +322,8 @@ struct ItemGrid: HashableView {
                         isSelectable = false
                     }
 
-                    do {
+                    await snackbarStore.notify(logger) {
                         try await itemStore.delete(selected)
-                    } catch {
-                        logger.error("\(error)")
                     }
                 }
             } label: { Text("削除する") }

--- a/OOTD/Views/Others/DependencyInjector.swift
+++ b/OOTD/Views/Others/DependencyInjector.swift
@@ -13,6 +13,7 @@ struct DependencyInjector<Content: View>: View {
     @StateObject private var itemStore = ItemStore()
     @StateObject private var outfitStore = OutfitStore()
     @StateObject private var navigation = NavigationManager()
+    @StateObject private var snackbarStore = SnackbarStore()
 
     var body: some View {
         NavigationStack(path: $navigation.path) {
@@ -21,6 +22,7 @@ struct DependencyInjector<Content: View>: View {
         .environmentObject(itemStore)
         .environmentObject(outfitStore)
         .environmentObject(navigation)
+        .environmentObject(snackbarStore)
         .task {
             Task {
                 do {

--- a/OOTD/Views/Outfit/OutfitDetail.swift
+++ b/OOTD/Views/Outfit/OutfitDetail.swift
@@ -14,6 +14,7 @@ struct OutfitDetail: HashableView {
     let mode: DetailMode
     @EnvironmentObject var outfitStore: OutfitStore
     @EnvironmentObject var navigation: NavigationManager
+    @EnvironmentObject var snackbarStore: SnackbarStore
 
     // MARK: - private
 
@@ -218,15 +219,13 @@ struct OutfitDetail: HashableView {
                                 navigation.path.removeLast()
                             }
 
-                            do {
+                            await snackbarStore.notify(logger) {
                                 switch mode {
                                 case .create:
                                     try await outfitStore.create([outfit])
                                 case .update:
                                     try await outfitStore.update([outfit], originalOutfits: [originalOutfit])
                                 }
-                            } catch {
-                                logger.error("\(error)")
                             }
                         }
                     }

--- a/OOTD/Views/Outfit/OutfitGrid.swift
+++ b/OOTD/Views/Outfit/OutfitGrid.swift
@@ -12,6 +12,7 @@ private let logger = getLogger(#file)
 struct OutfitGrid: View {
     @EnvironmentObject var outfitStore: OutfitStore
     @EnvironmentObject var navigation: NavigationManager
+    @EnvironmentObject var snackbarStore: SnackbarStore
     let numColumns: Int = 2
 
     @State private var isSelectable = false
@@ -244,10 +245,8 @@ struct OutfitGrid: View {
                         selected = []
                     }
 
-                    do {
+                    await snackbarStore.notify(logger) {
                         try await outfitStore.delete(selected)
-                    } catch {
-                        logger.error("\(error)")
                     }
                 }
             } label: { Text("削除する") }

--- a/OOTD/Views/RootView.swift
+++ b/OOTD/Views/RootView.swift
@@ -14,6 +14,7 @@ struct RootView: View {
     @StateObject private var outfitStore = OutfitStore(Config.DATA_SOURCE)
 
     @StateObject private var navigation = NavigationManager()
+    @StateObject private var snackbarStore = SnackbarStore()
 
     var body: some View {
         ZStack {
@@ -49,9 +50,11 @@ struct RootView: View {
                 LoadingView()
             }
         }
+        .snackbar(item: $snackbarStore.active) { $0 }
         .environmentObject(itemStore)
         .environmentObject(outfitStore)
         .environmentObject(navigation)
+        .environmentObject(snackbarStore)
         .task {
             do {
                 async let itemFetch: () = itemStore.fetch()

--- a/OOTD/Views/WebView/WebItemDetail.swift
+++ b/OOTD/Views/WebView/WebItemDetail.swift
@@ -30,6 +30,7 @@ struct WebItemDetail: HashableView {
 
     @EnvironmentObject var navigation: NavigationManager
     @EnvironmentObject var itemStore: ItemStore
+    @EnvironmentObject var snackbarStore: SnackbarStore
 
     func itemCard(_ item: Item) -> some View {
         ZStack(alignment: .bottomTrailing) {
@@ -161,9 +162,12 @@ struct WebItemDetail: HashableView {
                 Task { @MainActor in
                     defer {
                         navigation.path.removeLast()
+                    }
+
+                    await snackbarStore.notify(logger) {
+                        try await itemStore.create([item])
                         onCreated(item)
                     }
-                    try await itemStore.create([item])
                 }
             }
         }


### PR DESCRIPTION
# 目的

今まで *Store での書き込み時にエラーが発生した場合、ログを吐き出すか、握り潰すだけで、ユーザーからは成否が不明だった。ユーザーからも確認できるようにするため。また、エラーを握り潰さず、スナックバーに表示し、詳細はログに吐き出すように統一した。