### PR TITLE
アイテム更新時の前処理を EditItem ユースケースに移行

### DIFF
--- a/OOTD/ObservableObjects/ItemStore.swift
+++ b/OOTD/ObservableObjects/ItemStore.swift
@@ -122,42 +122,7 @@ class ItemStore: ObservableObject {
             isWriting = false
         }
 
-        let itemsToUpdate: [Item]
-
-        if originalItems.isEmpty {
-            itemsToUpdate = editedItems
-        } else if editedItems.count == originalItems.count {
-            itemsToUpdate = zip(originalItems, editedItems).compactMap { original, edited -> Item? in
-
-                if original == edited {
-                    return nil
-                }
-
-                logger.debug("""
-                original item:
-                    id: \(original.id)
-                    name: \(original.name)
-                    category: \(original.category.rawValue)
-
-                edited item:
-                    id: \(edited.id)
-                    name: \(edited.name)
-                    category: \(edited.category.rawValue)
-                """)
-
-                return edited
-            }
-        } else {
-            throw "originalItems is empty and originalItems.count != editedItems.count"
-        }
-
-        let now = Date()
-        let updatedItems = itemsToUpdate.map {
-            $0
-                .copyWith(\.updatedAt, value: now)
-        }
-
-        try await EditItems(repository: repository)(updatedItems)
+        let updatedItems = try await EditItems(repository: repository)(editedItems, originalItems: originalItems)
 
         for item in updatedItems {
             if let index = items.firstIndex(where: { $0.id == item.id }) {

--- a/OOTD/UseCases/Item/EditItems.swift
+++ b/OOTD/UseCases/Item/EditItems.swift
@@ -7,10 +7,51 @@
 
 import Foundation
 
+private let logger = getLogger(#file)
+
 struct EditItems {
     let repository: ItemRepository
 
-    func callAsFunction(_ items: [Item]) async throws {
-        try await repository.update(items)
+    // この関数内で .updatedAt などを更新するので、更新後の [Item] を返す必要がある
+    func callAsFunction(_ editedItems: [Item], originalItems: [Item]) async throws -> [Item] {
+        let itemsToUpdate: [Item]
+
+        if originalItems.isEmpty {
+            itemsToUpdate = editedItems
+        } else if editedItems.count == originalItems.count {
+            itemsToUpdate = zip(originalItems, editedItems).compactMap { original, edited -> Item? in
+
+                if original == edited {
+                    return nil
+                }
+
+                logger.debug("""
+                original item:
+                    id: \(original.id)
+                    name: \(original.name)
+                    category: \(original.category.rawValue)
+
+                edited item:
+                    id: \(edited.id)
+                    name: \(edited.name)
+                    category: \(edited.category.rawValue)
+                """)
+
+                return edited
+            }
+        } else {
+            // TODO: [(editItem, originalItem)] の対にすれば、ここは不要になりそう
+            throw "originalItems is empty and originalItems.count != editedItems.count"
+        }
+
+        let now = Date()
+        let updatedItems = itemsToUpdate.map {
+            $0
+                .copyWith(\.updatedAt, value: now)
+        }
+
+        try await repository.update(editedItems)
+
+        return updatedItems
     }
 }


### PR DESCRIPTION
# 目的

DDD および Clean Architecture に従い、アプリケーションロジックをユースケースに移行する