### PR TITLE
アイテム・コーデ一覧のスクロール初期位置を top に戻した

### DIFF
--- a/OOTD/ObservableObjects/ItemStore.swift
+++ b/OOTD/ObservableObjects/ItemStore.swift
@@ -54,7 +54,7 @@ class ItemStore: ObservableObject {
         queries = [defaultQuery] + Category.allCases.map { category in
             ItemQuery(
                 name: category.rawValue,
-                sort: .createdAtAscendant,
+                sort: .createdAtDescendant,
                 filter: .init(
                     category: category
                 )

--- a/OOTD/ObservableObjects/OutfitStore.swift
+++ b/OOTD/ObservableObjects/OutfitStore.swift
@@ -17,7 +17,7 @@ class OutfitStore: ObservableObject {
     @Published var searchText: String = ""
     @Published var query = OutfitQuery(
         name: "すべて",
-        sort: .createdAtAscendant
+        sort: .createdAtDescendant
     )
     @Published var displayedOutfits: [Outfit] = []
     private var cancellables = Set<AnyCancellable>()

--- a/OOTD/Views/Item/ItemGrid.swift
+++ b/OOTD/Views/Item/ItemGrid.swift
@@ -290,7 +290,6 @@ struct ItemGrid: HashableView {
                         .padding(spacing)
                         .padding(.bottom, 70)
                     }
-                    .defaultScrollAnchor(.bottom)
                     .background(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))
                 }
             } footer: {

--- a/OOTD/Views/Outfit/OutfitGrid.swift
+++ b/OOTD/Views/Outfit/OutfitGrid.swift
@@ -198,7 +198,6 @@ struct OutfitGrid: View {
                         .padding(.bottom, 70)
                         .padding(spacing)
                     }
-                    .defaultScrollAnchor(.bottom)
                     .background(Color(red: 240 / 255, green: 240 / 255, blue: 240 / 255))
 
                     bottomBar


### PR DESCRIPTION
# 理由

https://github.com/hrsma2i/ootd-ios/pull/5 のバグが再発し、解決策がすぐに見つからなかったので初期位置を bottom にするのをあきらめた。