### PR TITLE
Category を enum から struct に、新しいカテゴリーの追加

### DIFF
--- a/OOTD/Domain/Item/ValueObjects/Category.swift
+++ b/OOTD/Domain/Item/ValueObjects/Category.swift
@@ -12,9 +12,9 @@ struct Category: Codable, Comparable, Hashable {
     let id: Int
     let displayName: String
 
-    static let halfInnerTops = Category(id: 1, displayName: "Tシャツ・半袖シャツ")
-    static let longInnerTops = Category(id: 2, displayName: "シャツ・ロンT")
-    static let middleTops = Category(id: 3, displayName: "ニット・スウェット")
+    static let lightShortSleeveTops = Category(id: 1, displayName: "Tシャツ・半袖シャツ")
+    static let lightLongSleeveTops = Category(id: 2, displayName: "シャツ・ロンT")
+    static let heavyTops = Category(id: 3, displayName: "ニット・スウェット")
     static let outerwear = Category(id: 4, displayName: "アウター")
     static let bottoms = Category(id: 5, displayName: "ボトムス")
     static let shoes = Category(id: 6, displayName: "シューズ")
@@ -22,9 +22,9 @@ struct Category: Codable, Comparable, Hashable {
     static let uncategorized = Category(id: 1000, displayName: "未分類")
 
     static let allCases: [Category] = [
-        .halfInnerTops,
-        .longInnerTops,
-        .middleTops,
+        .lightShortSleeveTops,
+        .lightLongSleeveTops,
+        .heavyTops,
         .outerwear,
         .bottoms,
         .shoes,

--- a/OOTD/Domain/Item/ValueObjects/Category.swift
+++ b/OOTD/Domain/Item/ValueObjects/Category.swift
@@ -18,16 +18,27 @@ struct Category: Codable, Comparable, Hashable {
     static let outerwear = Category(id: 4, displayName: "アウター")
     static let bottoms = Category(id: 5, displayName: "ボトムス")
     static let shoes = Category(id: 6, displayName: "シューズ")
+    static let allInOne = Category(id: 7, displayName: "オールインワン")
+    static let headwear = Category(id: 8, displayName: "帽子")
+    static let legwear = Category(id: 9, displayName: "レッグウェア")
+    static let accessories = Category(id: 10, displayName: "アクセサリー")
+    static let bag = Category(id: 11, displayName: "カバン")
     static let others = Category(id: 999, displayName: "その他")
     static let uncategorized = Category(id: 1000, displayName: "未分類")
 
+    // よく使われる順にしてる
     static let allCases: [Category] = [
         .lightShortSleeveTops,
         .lightLongSleeveTops,
         .heavyTops,
         .outerwear,
         .bottoms,
+        .allInOne,
         .shoes,
+        .bag,
+        .legwear,
+        .headwear,
+        .accessories,
         .others,
         .uncategorized
     ]

--- a/OOTD/Domain/Item/ValueObjects/Category.swift
+++ b/OOTD/Domain/Item/ValueObjects/Category.swift
@@ -7,26 +7,71 @@
 
 import Foundation
 
-enum Category: String, Codable, CaseIterable, Comparable {
-    case halfInnerTops = "Tシャツ・半袖シャツ"
-    case longInnerTops = "シャツ・ロンT"
-    case middleTops = "ニット・スウェット"
-    case outerwear = "アウター"
-    case bottoms = "ボトムス"
-    case shoes = "シューズ"
-    case others = "その他"
-    case uncategorized = "未分類"
+// 将来的に英語版対応や、ユーザー定義カテゴリーの拡張を考慮し、 enum ではなく struct にしている
+struct Category: Codable, Comparable, Hashable {
+    let id: Int
+    let displayName: String
+
+    static let halfInnerTops = Category(id: 1, displayName: "Tシャツ・半袖シャツ")
+    static let longInnerTops = Category(id: 2, displayName: "シャツ・ロンT")
+    static let middleTops = Category(id: 3, displayName: "ニット・スウェット")
+    static let outerwear = Category(id: 4, displayName: "アウター")
+    static let bottoms = Category(id: 5, displayName: "ボトムス")
+    static let shoes = Category(id: 6, displayName: "シューズ")
+    static let others = Category(id: 999, displayName: "その他")
+    static let uncategorized = Category(id: 1000, displayName: "未分類")
+
+    static let allCases: [Category] = [
+        .halfInnerTops,
+        .longInnerTops,
+        .middleTops,
+        .outerwear,
+        .bottoms,
+        .shoes,
+        .others,
+        .uncategorized
+    ]
+
+    private init(id: Int, displayName: String) {
+        self.id = id
+        self.displayName = displayName
+    }
+
+    init?(rawValue: Int) {
+        guard let category = Self.allCases.first(where: { $0.id == rawValue }) else {
+            return nil
+        }
+        self = category
+    }
+
+    init?(displayName: String) {
+        guard let category = Self.allCases.first(where: { $0.displayName == displayName }) else {
+            return nil
+        }
+        self = category
+    }
 
     static var allCasesWithoutUncategorized: [Category] {
-        allCases.filter { $0 != .uncategorized }
+        return allCases.filter { $0 != .uncategorized }
     }
 
     static func < (lhs: Category, rhs: Category) -> Bool {
+        // id ではなく allCases の順番で比較
         guard let lhsIndex = allCases.firstIndex(of: lhs),
               let rhsIndex = allCases.firstIndex(of: rhs)
         else {
             return false
         }
+
         return lhsIndex < rhsIndex
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(displayName)
+    }
+
+    static func == (lhs: Category, rhs: Category) -> Bool {
+        return lhs.id == rhs.id && lhs.displayName == rhs.displayName
     }
 }

--- a/OOTD/Infrastructure/SwiftData/Schemas/V1/ItemDTOV1.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V1/ItemDTOV1.swift
@@ -23,7 +23,7 @@ extension SchemaV1 {
         // この原因は id に @Attribute(.unique) 制約があるから。なので、すでに保存済み（update, delete）の場合は container から取得する。
         init(item: Item) {
             id = item.id
-            category = item.category.rawValue
+            category = item.category.displayName
             sourceUrl = item.sourceUrl
             outfits = []
         }

--- a/OOTD/Infrastructure/SwiftData/Schemas/V2/ItemDTOV2.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V2/ItemDTOV2.swift
@@ -25,7 +25,7 @@ extension SchemaV2 {
         init(item: Item) {
             id = item.id
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             sourceUrl = item.sourceUrl
             outfits = []
         }

--- a/OOTD/Infrastructure/SwiftData/Schemas/V3/ItemDTOV3.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V3/ItemDTOV3.swift
@@ -27,7 +27,7 @@ extension SchemaV3 {
         init(item: Item) {
             id = item.id
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             sourceUrl = item.sourceUrl
             createdAt = item.createdAt!
             updatedAt = item.updatedAt!
@@ -35,7 +35,7 @@ extension SchemaV3 {
         }
 
         func toItem() throws -> Item {
-            guard let category = Category(rawValue: category) else {
+            guard let category = Category(displayName: category) else {
                 throw "[ItemDTO.toItem] failed to convert ItemDTO to Item. unknown category: \(category)"
             }
 

--- a/OOTD/Infrastructure/SwiftData/Schemas/V4/ItemDTOV4.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V4/ItemDTOV4.swift
@@ -36,7 +36,7 @@ extension SchemaV4 {
         init(item: Item) {
             id = item.id
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
             createdAt = item.createdAt!
@@ -52,7 +52,7 @@ extension SchemaV4 {
 
         func update(from item: Item) {
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
             updatedAt = item.updatedAt!
@@ -66,7 +66,7 @@ extension SchemaV4 {
         }
 
         func toItem() throws -> Item {
-            guard let category = Category(rawValue: category) else {
+            guard let category = Category(displayName: category) else {
                 throw "[ItemDTO.toItem] failed to convert ItemDTO to Item. unknown category: \(category)"
             }
 

--- a/OOTD/Infrastructure/SwiftData/Schemas/V5/ItemDTOV5.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V5/ItemDTOV5.swift
@@ -37,7 +37,7 @@ extension SchemaV5 {
         init(item: Item) {
             id = item.id
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             tags = item.tags
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
@@ -54,7 +54,7 @@ extension SchemaV5 {
 
         func update(from item: Item) {
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             tags = item.tags
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
@@ -69,7 +69,7 @@ extension SchemaV5 {
         }
 
         func toItem() throws -> Item {
-            guard let category = Category(rawValue: category) else {
+            guard let category = Category(displayName: category) else {
                 throw "[ItemDTO.toItem] failed to convert ItemDTO to Item. unknown category: \(category)"
             }
 

--- a/OOTD/Infrastructure/SwiftData/Schemas/V6/ItemDTOV6.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V6/ItemDTOV6.swift
@@ -37,7 +37,7 @@ extension SchemaV6 {
         init(item: Item) {
             id = item.id
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             tags = item.tags
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
@@ -54,7 +54,7 @@ extension SchemaV6 {
 
         func update(from item: Item) {
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             tags = item.tags
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
@@ -69,7 +69,7 @@ extension SchemaV6 {
         }
 
         func toItem() throws -> Item {
-            guard let category = Category(rawValue: category) else {
+            guard let category = Category(displayName: category) else {
                 throw "[ItemDTO.toItem] failed to convert ItemDTO to Item. unknown category: \(category)"
             }
 

--- a/OOTD/Infrastructure/SwiftData/Schemas/V7/ItemDTOV7.swift
+++ b/OOTD/Infrastructure/SwiftData/Schemas/V7/ItemDTOV7.swift
@@ -37,7 +37,7 @@ extension SchemaV7 {
         init(item: Item) {
             id = item.id
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             tags = item.tags
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
@@ -54,7 +54,7 @@ extension SchemaV7 {
 
         func update(from item: Item) {
             name = item.name
-            category = item.category.rawValue
+            category = item.category.displayName
             tags = item.tags
             purchasedPrice = item.purchasedPrice
             purchasedOn = item.purchasedOn
@@ -69,7 +69,7 @@ extension SchemaV7 {
         }
 
         func toItem() throws -> Item {
-            guard let category = Category(rawValue: category) else {
+            guard let category = Category(displayName: category) else {
                 throw "[ItemDTO.toItem] failed to convert ItemDTO to Item. unknown category: \(category)"
             }
 

--- a/OOTD/ObservableObjects/ItemStore.swift
+++ b/OOTD/ObservableObjects/ItemStore.swift
@@ -51,7 +51,7 @@ class ItemStore: ObservableObject {
         )
         queries = [defaultQuery] + Category.allCases.map { category in
             ItemQuery(
-                name: category.rawValue,
+                name: category.displayName,
                 sort: .createdAtDescendant,
                 filter: .init(
                     category: category

--- a/OOTD/Repositories/Item/SampleItemRepository.swift
+++ b/OOTD/Repositories/Item/SampleItemRepository.swift
@@ -32,14 +32,14 @@ let sampleItems = [
         imageSource: .url("https://lh3.googleusercontent.com/pw/AP1GczN37a2OxZWuuFhgc0V5mgEUM76wf8xwGgkOiwJkRvfisUHr-a6XbVDbNgZVEyNK2fKR0tXB_JL7xZMIgxNS7mwPYT2vSKdzavCUmmpeQpvpuD0SG-0=w2400"),
         option: .init(
             name: "famima t shirts",
-            category: .halfInnerTops
+            category: .lightShortSleeveTops
         )
     ),
     Item(
         imageSource: .url("https://lh3.googleusercontent.com/pw/AP1GczOCGS6_8gRn_I1h9P1wgLr7vZEHIPVmPN6xqWt6l4DK1Y1ZzpEBwjbDlD8gxdaGDZkr6h4H8zdUPcb2BQY5lbhNdGaB4ItB_mGWYDDpEimTWkf41jU=w2400"),
         option: .init(
             name: "adidas pique",
-            category: .longInnerTops
+            category: .lightLongSleeveTops
         )
     ),
     Item(
@@ -81,7 +81,7 @@ let sampleItems = [
         imageSource: .url("https://lh3.googleusercontent.com/pw/AP1GczOIMlFQxM0XWXZM8M9AvfS2S0oJXkoPahRzByLYuhonmOx-UZQj8aoHx_u8fxH-w903lO2h61T8d7hFHcD8-zTBdAds1DaFi9yzKZX2-JZ7ahViK6A=w2400"),
         option: .init(
             name: "gray sweat",
-            category: .middleTops
+            category: .heavyTops
         )
     ),
     Item(

--- a/OOTD/Repositories/Item/SwiftDataItemRepository.swift
+++ b/OOTD/Repositories/Item/SwiftDataItemRepository.swift
@@ -24,6 +24,7 @@ final class SwiftDataItemRepository: ItemRepository {
         context = SwiftDataManager.shared.context
     }
 
+    @MainActor
     func findAll() async throws -> [Item] {
         logger.debug("fetch all items")
         let descriptor = FetchDescriptor<ItemDTO>()

--- a/OOTD/Repositories/Outfit/SwiftDataOutfitRepository.swift
+++ b/OOTD/Repositories/Outfit/SwiftDataOutfitRepository.swift
@@ -10,8 +10,6 @@ import Foundation
 import SwiftData
 import UIKit
 
-
-
 typealias OutfitDTO = SchemaV7.OutfitDTO
 
 final class SwiftDataOutfitRepository: OutfitRepository {
@@ -37,6 +35,7 @@ final class SwiftDataOutfitRepository: OutfitRepository {
         return dto
     }
 
+    @MainActor
     func findAll() async throws -> [Outfit] {
         logger.debug("fetch all outfits")
         let descriptor = FetchDescriptor<OutfitDTO>()

--- a/OOTD/UseCases/Item/EditItems.swift
+++ b/OOTD/UseCases/Item/EditItems.swift
@@ -45,12 +45,12 @@ struct EditItems {
                 original item:
                     id: \(original.id)
                     name: \(original.name)
-                    category: \(original.category.rawValue)
+                    category: \(original.category.displayName)
                 
                 edited item:
                     id: \(edited.id)
                     name: \(edited.name)
-                    category: \(edited.category.rawValue)
+                    category: \(edited.category.displayName)
                 """)
             }
         }

--- a/OOTD/UseCases/Item/GetItems.swift
+++ b/OOTD/UseCases/Item/GetItems.swift
@@ -10,6 +10,7 @@ import Foundation
 struct GetItems {
     let repository: ItemRepository
 
+    @MainActor
     func callAsFunction() async throws -> [Item] {
         let items = try await repository.findAll()
         return items

--- a/OOTD/UseCases/Outfit/GetOutfits.swift
+++ b/OOTD/UseCases/Outfit/GetOutfits.swift
@@ -10,6 +10,7 @@ import Foundation
 struct GetOutfits {
     let repository: OutfitRepository
 
+    @MainActor
     func callAsFunction() async throws -> [Outfit] {
         let outfits = try await repository.findAll()
         return outfits

--- a/OOTD/Views/Item/ItemDetail.swift
+++ b/OOTD/Views/Item/ItemDetail.swift
@@ -49,7 +49,7 @@ struct ItemDetail: HashableView {
     
     var categoryDisplayed: String {
         if let category = items.first?.category, items.allSatisfy({ $0.category == category }) {
-            return category.rawValue
+            return category.displayName
         }
         return "バラバラ"
     }

--- a/OOTD/Views/Sheets/CategorySelectSheet.swift
+++ b/OOTD/Views/Sheets/CategorySelectSheet.swift
@@ -35,10 +35,10 @@ struct CategorySelectSheet: HashableView {
                     return "すべて"
                 }
 
-                return category.rawValue
+                return category.displayName
             }
         ) {
-            onSelect(Category(rawValue: $0))
+            onSelect(Category(displayName: $0))
         }
     }
 }


### PR DESCRIPTION
# 主な変更と理由

## (1) Category を enum から struct にした。理由は以下:

- 将来的に表示名を変えやすくするため、
  - String の enum だと、データベースをすべて書き直す必要が出てくるが、 struct であれば、 displayName だけ変えればよいから
  - なぜ Int の enum　にして、 DB にカテゴリーマスタを用意し、 displyaName を保存しないか：表示名を変えたいときカテゴリーマスタを書き換える必要があるから
- Item 側の DB には Category の ID だけ保存しておいたほうがパフォーマンスが良いから
- 多言語対応しやすくするため
  - id, displayName だけでなく、英語名なども持たせやすいから（ enum に displayName の computed property を持たせて、 switch 文で変換する方法だと、言語の数だけ switch 文を書くことになり、対応が分かりづらいため）


なお、外からは enum と同じインターフェースにすることで変更差分を小さくし、 enum に戻りやすくもした。


## (2) 新しいカテゴリーの追加

- オールインワン
- 帽子
- レッグウェア
- アクセサリー
- カバン