### PR TITLE
クライアントサイドジョインを OutfitStore から GetOutfits ユースケースに移行

### DIFF
--- a/OOTD/Repositories/Outfit/LocalJsonOutfitRepository.swift
+++ b/OOTD/Repositories/Outfit/LocalJsonOutfitRepository.swift
@@ -37,6 +37,8 @@ extension Outfit: Codable {
 }
 
 struct LocalJsonOutfitRepository: OutfitRepository {
+    var shouldClientSideJoin: Bool { true }
+
     static let shared: LocalJsonOutfitRepository = .init()
 
     private init() {}

--- a/OOTD/Repositories/Outfit/OutfitRepository.swift
+++ b/OOTD/Repositories/Outfit/OutfitRepository.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 protocol OutfitRepository {
+    var shouldClientSideJoin: Bool { get }
+
     func findAll() async throws -> [Outfit]
 
     func save(_ outfits: [Outfit]) async throws

--- a/OOTD/Repositories/Outfit/SampleOutfitRepository.swift
+++ b/OOTD/Repositories/Outfit/SampleOutfitRepository.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 class SampleOutfitRepository: OutfitRepository {
+    var shouldClientSideJoin: { false }
+
     func findAll() async throws -> [Outfit] {
         sampleOutfits
     }

--- a/OOTD/Repositories/Outfit/SwiftDataOutfitRepository.swift
+++ b/OOTD/Repositories/Outfit/SwiftDataOutfitRepository.swift
@@ -13,6 +13,7 @@ import UIKit
 typealias OutfitDTO = SchemaV7.OutfitDTO
 
 final class SwiftDataOutfitRepository: OutfitRepository {
+    var shouldClientSideJoin: Bool { true }
     var context: ModelContext
 
     @MainActor

--- a/OOTD/Views/Others/DependencyInjector.swift
+++ b/OOTD/Views/Others/DependencyInjector.swift
@@ -27,7 +27,7 @@ struct DependencyInjector<Content: View>: View {
             Task {
                 do {
                     try await itemStore.fetch()
-                    try await outfitStore.fetch()
+                    try await outfitStore.fetch(itemsToJoin: itemStore.items)
                 }
             }
         }

--- a/OOTD/Views/RootView.swift
+++ b/OOTD/Views/RootView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-
-
 struct RootView: View {
     @StateObject private var itemStore = ItemStore(Config.DATA_SOURCE)
     @StateObject private var outfitStore = OutfitStore(Config.DATA_SOURCE)
@@ -57,13 +55,8 @@ struct RootView: View {
         .environmentObject(snackbarStore)
         .task {
             do {
-                async let itemFetch: () = itemStore.fetch()
-                async let outfitFetch: () = outfitStore.fetch()
-
-                try await itemFetch
-                try await outfitFetch
-
-                outfitStore.joinItems(itemStore.items)
+                try await itemStore.fetch()
+                try await outfitStore.fetch(itemsToJoin: itemStore.items)
             } catch {
                 logger.critical("\(error.localizedDescription)")
             }

--- a/OOTD/Views/Sheets/ItemDeleteConfirmOutfitsSheet.swift
+++ b/OOTD/Views/Sheets/ItemDeleteConfirmOutfitsSheet.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-
-
 struct ItemDeleteConfirmOutfitsSheet: View {
     let items: [Item]
     let relatedOutfits: [Outfit]
@@ -170,12 +168,12 @@ struct ItemDeleteConfirmOutfitsSheet: View {
 #Preview {
     @MainActor
     struct PreviewView: View {
-        let outfitStore = OutfitStore()
-        let itemStore = ItemStore()
         let items = sampleItems.filter { ["black_cocoon_denim", "white_ma1"].contains($0.id) }
         @State private var outfits: [Outfit] = []
         @State private var path = NavigationPath()
         @State private var isSheetPresented = true
+        @EnvironmentObject var outfitStore: OutfitStore
+        @EnvironmentObject var itemStore: ItemStore
 
         var body: some View {
             Button {
@@ -192,11 +190,6 @@ struct ItemDeleteConfirmOutfitsSheet: View {
                 }
                 .task {
                     do {
-                        try await itemStore.fetch()
-                        try await outfitStore.fetch()
-
-                        outfitStore.joinItems(itemStore.items)
-
                         outfits = try await InMemorySearchOutfits(outfits: outfitStore.outfits)(usingAny: items)
                     } catch {}
                 }
@@ -206,5 +199,7 @@ struct ItemDeleteConfirmOutfitsSheet: View {
         }
     }
 
-    return PreviewView()
+    return DependencyInjector {
+        PreviewView()
+    }
 }


### PR DESCRIPTION
# 目的

OutfitStore に join ロジックが張り付いていたため、バックアップから import する際に join ロジックが呼ばれず、インポート後にアプリを再起動すると、各 Outfit の .items が空になっていた（ import した際に UI は更新されたが、 SwiftDataOutfitRepository に Outfit.itemIds が空になっていたっぽい）


# 動作確認

インポート後に再起動し、各 outfit に .items が登録されていることを確認した。